### PR TITLE
create pages using multiple data files and one template

### DIFF
--- a/lib/punch.js
+++ b/lib/punch.js
@@ -1,4 +1,5 @@
 var fs = require("fs");
+var path = require("path");
 var util = require("util");
 var child_process = require('child_process');
 var _ = require("underscore");
@@ -241,7 +242,7 @@ module.exports = {
     var content_type = filename_and_extensions.pop();
 
     // get the intended extension
-    var intended_extension = filename_and_extensions.pop();
+    var intended_extension = filename_and_extensions.pop() || config.output_extension;
 
     //remove the template directory name from indentifer
     content_identifier.shift();
@@ -263,7 +264,7 @@ module.exports = {
       var output_file_path = output_dirs.join("/");
 
       // set the extension if the output file path doesn't already have an extension 
-      output_file_path = output_file_path + "." + (intended_extension || config.output_extension);
+      output_file_path = output_file_path + "." + intended_extension;
 
       fs.writeFile(output_file_path, output, function(err){
         if(err) throw err;
@@ -280,16 +281,40 @@ module.exports = {
       }
     });
 
-    // fetch content (with shared content)
-    self.fetchSharedContent(config.content_dir + "/" + config.shared_content, function(shared_content){
-      self.fetchContent(content_path, function(content){
-        renderer.setContent(_.extend(shared_content, content));       
-      });
-    });
-
     // fetch partials
     self.fetchPartials(partials_path, function(partials){
       renderer.setPartials(partials);       
+    });
+
+    // fetch content (with shared content)
+    self.fetchSharedContent(config.content_dir + "/" + config.shared_content, function(shared_content){
+      var dirExists = path.existsSync(content_path) && fs.statSync(content_path).isDirectory();
+      var dataExists = path.existsSync(content_path + ".json");
+
+      if (dirExists && !dataExists) {
+        fs.readdir(content_path, function(err, files) {
+          if (err)
+            return;
+          files.forEach(function(content_file) {
+            var content_file_base = path.basename(content_file, ".json");
+
+            var output_dirs = [config.output_dir].concat(content_identifier);
+            var output_file_path = output_dirs.join("/");
+            try {
+              fs.mkdirSync(output_file_path);
+            } catch(err) { } // ignore the errors since failing probably means it exists
+
+            self.fetchContent(content_path + "/" + content_file_base, function(content) {
+              var output_file = output_file_path + "/" + content_file_base + "." + intended_extension;
+              renderer.renderTo(_.extend(shared_content, content), output_file);
+            });
+          });
+        });
+      } else {
+        self.fetchContent(content_path, function(content){
+          renderer.setContent(_.extend(shared_content, content));
+        });
+      }
     });
 
   },

--- a/lib/renderers/mustache.js
+++ b/lib/renderers/mustache.js
@@ -3,6 +3,8 @@
  * Based on Mustache.js - https://github.com/janl/mustache.js 
 */
 
+var fs = require("fs");
+
 if(typeof require !== "undefined"){
   var Mustache = require("mustache");
 }
@@ -46,6 +48,15 @@ MustacheRenderer.prototype.render = function(){
   } else {
     return output; 
   }
+}
+
+MustacheRenderer.prototype.renderTo = function(content, output_file_path) {
+  var output = Mustache.render(this.template, content, this.partials);
+
+  fs.writeFile(output_file_path, output, function(err){
+    if(err) throw err;
+    console.log("Created " + output_file_path );
+  });
 }
 
 if(typeof module !== "undefined" && module.exports){


### PR DESCRIPTION
Here is code describing the feature I requested in email. It's not integrated well and I don't expect this to be merged as-is, but it does demonstrate the effect I was going for. If you have a .mustache file in /templates, no corresponding .json file in contents, have a directory with the same name as the mustache template, and have .json files in that directory then this code will create one .html file in public/<template>/ for each .json file in the the directory. So:
/templates/pages.mustache
/contents/pages/one.json
/contents/pages/two.json

will produce:

/public/pages/one.html
/public/pages/two.html
