### PR TITLE
Page contents overriding shared contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 todo
-*/**/.DS_Store
+*.DS_Store
 example/public
+node_modules

--- a/lib/content_handler.js
+++ b/lib/content_handler.js
@@ -299,7 +299,7 @@ module.exports = {
 				//fetch shared content
 				self.getSharedContent(function(err, shared_content, shared_modified_date) {
 					if (!err) {
-						collected_contents = _.extend(collected_contents, shared_content);
+						collected_contents = _.extend(shared_content, collected_contents);
 						if (shared_modified_date > last_modified) {
 							last_modified = shared_modified_date;
 						}


### PR DESCRIPTION
In punch@0.3 a page contents could override the shared contents.  
This is a useful comportment that we relied on to have a submenu only on certain pages.
