### PR TITLE
Update boilerplates/default/templates/_header.mustache

### DIFF
--- a/boilerplates/default/templates/_header.mustache
+++ b/boilerplates/default/templates/_header.mustache
@@ -21,7 +21,7 @@
 
 				<ul class="navbar">
 				{{#navbar}}
-					<li><a href="{{href}}">{{label}}</a>
+					<li><a href="{{{href}}}">{{label}}</a>
 				{{/navbar}}
 				</ul>
 			</header>


### PR DESCRIPTION
Default hrefs should be unescaped.
Otherwise you end up with crazy shit like `href="&#x2F;about"`
