### PR TITLE
Fixing robocopy (windows) exit code issue

### DIFF
--- a/lib/project_creator.js
+++ b/lib/project_creator.js
@@ -35,7 +35,8 @@ module.exports = {
 			}
 
 			child_process.exec(copy_command, function(err, stdout, stderr) {
-				if(err) {
+				if (err && os.platform() === "win32" && err.code <= 3) {
+				} else if(err) {
 					throw err;
 				}
 


### PR DESCRIPTION
Successful exit code for robocopy is not necessarily 0, it can also be 1, 2 or 3 as per http://ss64.com/nt/robocopy-exit.html

Checking if we are running robocopy in windows and not triggering error on anything 3 or less.
