### PR TITLE
cssmin broke css bundling because of how it does module export now

### DIFF
--- a/lib/minifiers/cssmin.js
+++ b/lib/minifiers/cssmin.js
@@ -1,4 +1,4 @@
-var cssminPkg = require("cssmin");
+var cssmin = require("cssmin");
 
 module.exports = {
 	input_extensions: [".css"],
@@ -8,7 +8,7 @@ module.exports = {
 		var output, err;
 
 		try {
-			output = cssminPkg.cssmin(input);
+			output = cssmin(input);
 		} catch(error) {
 			err = error;
 		}


### PR DESCRIPTION
Latest version of cssmin directly exports a function now so it broke punch minification

I am not certain how to do jasmine spies on a function that has been imported so didn't fix the specs (they are broken right now due to cssmin changes).
