### PR TITLE
Fixing windows path matching

### DIFF
--- a/lib/site_generator.js
+++ b/lib/site_generator.js
@@ -123,7 +123,7 @@ module.exports = {
 
 			_.each(self.pathsToSkip, function(skip_pattern) {
 				_.each(from, function(path) {
-					if (path.match(skip_pattern) !== null) {
+					if (path_utils.matchPath(path, skip_pattern) !== null) {
 						paths_to_skip.push(path);
 					}
 				});

--- a/lib/utils/path_utils.js
+++ b/lib/utils/path_utils.js
@@ -1,5 +1,7 @@
 var path = require("path");
 var mime = require("mime");
+var os = require("os");
+var _ = require("underscore");
 
 module.exports = {
 
@@ -28,6 +30,23 @@ module.exports = {
 		} else {
 			return request_path;
 		}
-	}
+	},
 
+	matchPath: function(basepath, patterns) {
+		function match(file_path, regex)
+		{
+			if (os.platform() === "win32") {
+				return file_path.replace(/\\/g, "/").match( new RegExp(regex) );
+			}
+			return file_path.match( new RegExp(regex) );
+		}
+		if (Array.isArray(patterns)) {
+			return _.any(patterns, function(pattern) {
+				return match(basepath, pattern) != null;
+			});
+		} else {
+			// assume a single pattern given and match directly
+			return match(basepath, patterns);
+		}
+	}
 };

--- a/spec/utils/path_utils.spec.js
+++ b/spec/utils/path_utils.spec.js
@@ -35,3 +35,47 @@ describe("get the basename", function() {
 	});
 
 });
+
+describe("match a path", function() {
+
+	it("matches a single path", function() {
+		var matches = path_utils.matchPath("/css/less/main.less", "/css/less/*");
+		expect(matches[0]).toEqual("/css/less/");
+	});
+
+	it("matches a single path on windows", function() {
+		var matches = path_utils.matchPath("\\css\\less\\main.less", "/css/less/*");
+		expect(matches[0]).toEqual("/css/less/");
+	});
+
+	it("matches multiple paths", function() {
+		var matches = path_utils.matchPath("/css/less/main.less", ["/css/less/*", "/css/sass/*"]);
+		expect(matches).toBeTruthy();
+	});
+
+	it("matches multiple paths on windows", function() {
+		var matches = path_utils.matchPath("\\css\\less\\main.less", ["/css/less/*", "/css/sass/*"]);
+		expect(matches).toBeTruthy();
+	});
+
+	it("fails a match on single path", function() {
+		var matches = path_utils.matchPath("/css/less/main.less", "/css/sass/*");
+		expect(matches).toBeFalsy();
+	});
+
+	it("fails a match on single path on windows", function() {
+		var matches = path_utils.matchPath("\\css\\less\\main.less", "/css/sass/*");
+		expect(matches).toBeFalsy();
+	});
+
+	it("fails a match on multiple paths", function() {
+		var matches = path_utils.matchPath("/css/less/main.less", ["/css/les/*", "/css/sass/*"]);
+		expect(matches).toBeTruthy();
+	});
+
+	it("fails a match on multiple paths on windows", function() {
+		var matches = path_utils.matchPath("\\css\\less\\main.less", ["/css/les/*", "/css/sass/*"]);
+		expect(matches).toBeTruthy();
+	});
+
+});


### PR DESCRIPTION
added matchPath
It's used to match '/' based paths even in windows
This is in preparation for fixing punch blog for windows and it fixes skip_paths not working in windows.

I have a mostly working blog under windows but had to create this https://github.com/laktek/punch-blog-content-handler/issues/8 since I can't find version 0.0.8
