### PR TITLE
Fix issues with mimeType not matching on 0

### DIFF
--- a/lib/utils/path_utils.js
+++ b/lib/utils/path_utils.js
@@ -13,7 +13,7 @@ module.exports = {
 		} else {
 			var best_access_type = accept_types.length && accept_types.shift()["mediarange"];
 
-			return "." + (Mime.extension(best_access_type) || "html");
+			return "." + ((best_access_type && Mime.extension(best_access_type)) || "html");
 		}
 	},
 


### PR DESCRIPTION
When generating a site, I keep encountering an issue where mimeType is not matching on 0

var type = mimeType.match(/^\s_([^;\s]_)(?:;|\s|$)/)[1].toLowerCase();
                      ^
TypeError: Object false has no method 'match'

This is because the 'accept_types' arg of 'getExtension' is an empty array
