### PR TITLE
bug fix: partials do not render on windows 7.

### DIFF
--- a/lib/template_handler.js
+++ b/lib/template_handler.js
@@ -19,7 +19,7 @@ module.exports = {
 			return false;
 		}
 
-		var path_portions = template_path.split(Path.sep || "/");
+		var path_portions = template_path.split("/");
 		if(_.any(path_portions, function(portion){ return portion[0] === "."; })){
 			return false;
 		}
@@ -232,7 +232,7 @@ module.exports = {
 		};
 
 		var directories_to_look = [];
-		_.each(basePath.split(Path.sep || "/"), function(current_dir_entry){
+		_.each(basePath.split("/"), function(current_dir_entry){
 			var previous_dir_entry;
 
 			if(directories_to_look.length) {


### PR DESCRIPTION
I was attempting to follow the Punch setup tutorial but partials weren't rendering. I found the fix for the
problem here:
https://github.com/laktek/punch/issues/102

My system is Windows 7 64bit.

Partials are now rendering after applying the fix. I have no idea what effects the changes will have when run on OSX and other operating systems. Sorry. 